### PR TITLE
Improve result sorting

### DIFF
--- a/dfrndir.sql
+++ b/dfrndir.sql
@@ -1,4 +1,4 @@
--- Generation Time: Apr 21, 2017 at 03:58 AM
+-- Generation Time: Oct 26, 2018 at 05:31 AM
 
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 SET time_zone = "+00:00";
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS `flag` (
   `reason` int(11) NOT NULL,
   `total` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS `photo` (
   `data` mediumblob NOT NULL,
   `score` float NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=2516 DEFAULT CHARSET=utf8mb4;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -53,20 +53,16 @@ CREATE TABLE IF NOT EXISTS `profile` (
   `homepage` char(255) NOT NULL,
   `photo` char(255) NOT NULL,
   `tags` longtext NOT NULL,
+  `filled_fields` tinyint(4) NOT NULL DEFAULT '0',
+  `last_activity` varchar(7) DEFAULT NULL,
   `available` tinyint(1) NOT NULL DEFAULT '1',
   `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `updated` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `censored` tinyint(4) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `name` (`name`(250)),
   KEY `nurl` (`nurl`(250)),
-  KEY `comm` (`comm`),
-  KEY `pdesc` (`pdesc`(250)),
-  KEY `locality` (`locality`(250)),
-  KEY `region` (`region`(250)),
-  KEY `country-name` (`country-name`(250)),
-  KEY `homepage` (`homepage`(250))
-) ENGINE=MyISAM AUTO_INCREMENT=2518 DEFAULT CHARSET=utf8mb4;
+  KEY `profile_sorting` (`filled_fields`,`last_activity`,`updated`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -82,7 +78,7 @@ CREATE TABLE IF NOT EXISTS `session` (
   PRIMARY KEY (`id`),
   KEY `sid` (`sid`(250)),
   KEY `expire` (`expire`)
-) ENGINE=MyISAM AUTO_INCREMENT=22917 DEFAULT CHARSET=utf8mb4;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -130,10 +126,10 @@ CREATE TABLE IF NOT EXISTS `site-health` (
   `ssl_state` bit(1) DEFAULT NULL,
   `ssl_grade` varchar(3) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `base_url` (`base_url`(250)),
+  UNIQUE KEY `base_url` (`base_url`(250)) USING BTREE,
   KEY `health_score` (`health_score`),
   KEY `dt_last_seen` (`dt_last_seen`)
-) ENGINE=MyISAM AUTO_INCREMENT=10035 DEFAULT CHARSET=utf8mb4;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -151,7 +147,7 @@ CREATE TABLE IF NOT EXISTS `site-probe` (
   PRIMARY KEY (`id`),
   KEY `site_health_id` (`site_health_id`),
   KEY `dt_performed` (`dt_performed`)
-) ENGINE=MyISAM AUTO_INCREMENT=28987 DEFAULT CHARSET=utf8mb4;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -170,7 +166,7 @@ CREATE TABLE IF NOT EXISTS `site-scrape` (
   PRIMARY KEY (`id`),
   KEY `site_health_id` (`site_health_id`),
   KEY `dt_performed` (`dt_performed`)
-) ENGINE=MyISAM AUTO_INCREMENT=177675 DEFAULT CHARSET=utf8mb4;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
 
 -- --------------------------------------------------------
 
@@ -257,5 +253,4 @@ CREATE TABLE IF NOT EXISTS `user` (
 --
 -- Indexes for table `profile`
 --
-ALTER TABLE `profile` ADD FULLTEXT KEY `tags` (`tags`);
 ALTER TABLE `profile` ADD FULLTEXT KEY `profile-ft` (`name`,`pdesc`,`homepage`,`locality`,`region`,`country-name`,`tags`);

--- a/include/submit.php
+++ b/include/submit.php
@@ -115,6 +115,11 @@ function run_submit($url)
 		$params['comm'] = intval($params['comm']);
 	}
 
+	$filled_fields =
+		intval(!empty($params['pdesc'])) * 4
+		+ intval(!empty($params['tags'])) * 2
+		+ intval(!empty($params['locality']) || !empty($params['region']) || !empty($params['postal-code']) || !empty($params['country-name']));
+
 	if ($profile_exists) {
 		$r = q("UPDATE `profile` SET
 			`name` = '%s',
@@ -127,6 +132,8 @@ function run_submit($url)
 			`nurl` = '%s',
 			`comm` = %d,
 			`tags` = '%s',
+			`filled_fields` = %d,
+			`last_activity` = '%s',
 			`available` = 1,
 			`updated` = '%s'
 			WHERE `id` = %d LIMIT 1",
@@ -140,13 +147,29 @@ function run_submit($url)
 			dbesc($nurl),
 			intval($params['comm']),
 			$params['tags'],
+			$filled_fields,
+			x($params, 'last-activity') ? $params['last-activity'] : NULL,
 			dbesc(datetime_convert()),
 			intval($profile_id)
 		);
 		logger('Update returns: ' . $r);
 	} else {
-		$r = q("INSERT INTO `profile` ( `name`, `pdesc`, `locality`, `region`, `postal-code`, `country-name`, `homepage`, `nurl`, `comm`, `tags`, `created`, `updated` )
-			VALUES ( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', %d, '%s', '%s', '%s' )",
+		$r = q("INSERT INTO `profile` SET
+			`name` = '%s',
+			`pdesc` = '%s',
+			`locality` = '%s',
+			`region` = '%s',
+			`postal-code` = '%s',
+			`country-name` = '%s',
+			`homepage` = '%s',
+			`nurl` = '%s',
+			`comm` = %d,
+			`tags` = '%s',
+			`filled_fields` = %d,
+			`last_activity` = '%s',
+			`available` = 1,
+			`created` = '%s',
+			`updated` = '%s'",
 			$params['fn'],
 			x($params, 'pdesc') ? $params['pdesc'] : '',
 			x($params, 'locality') ? $params['locality'] : '',
@@ -157,6 +180,8 @@ function run_submit($url)
 			dbesc($nurl),
 			intval($params['comm']),
 			x($params, 'tags') ? $params['tags'] : '',
+			$filled_fields,
+			x($params, 'last-activity') ? $params['last-activity'] : NULL,
 			dbesc(datetime_convert()),
 			dbesc(datetime_convert())
 		);

--- a/mod/directory.php
+++ b/mod/directory.php
@@ -62,7 +62,7 @@ function directory_content(App $a)
 	if ($alpha) {
 		$order = ' ORDER BY `name` ASC ';
 	} else {
-		$order = ' ORDER BY `updated` DESC, `id` DESC ';
+		$order = ' ORDER BY `filled_fields` DESC, `last_activity` DESC, `updated` DESC';
 	}
 
 	$r = q("SELECT * FROM `profile` WHERE `censored` = 0 AND `available` = 1 $sql_extra $order LIMIT %d , %d ",

--- a/src/templates/view/_profile.php
+++ b/src/templates/view/_profile.php
@@ -9,8 +9,16 @@
         <div class="location">
             <?php
                 $parts = array();
-                if(!empty($profile['locality'])) $parts[] = $profile['locality'];
-                if(!empty($profile['country-name'])) $parts[] = $profile['country-name'];
+                if(!empty($profile['locality'])) {
+					$parts[] = $profile['locality'];
+				}
+                if(!empty($profile['region'])
+					&& strtolower($profile['locality']) != strtolower($profile['region'])) {
+					$parts[] = $profile['region'];
+				}
+                if(!empty($profile['country-name'])) {
+					$parts[] = $profile['country-name'];
+				}
             ?>
 
             <?php if (count($parts)): ?>


### PR DESCRIPTION
I finally got around to implement sorting by last activity. In the process, I also sort on number of filled profile fields so that the most verbose results show up first.

The number of filled profile fields is weighted:
- Description earned 4 points
- Tags earns 2 points
- Any number of location fields earn 1 point

The profile card now show the region if it isn't the same string as the locality.

Thanks to Adam Clarke for the nudge.